### PR TITLE
Implement Echo+ agent

### DIFF
--- a/a2a_example.py
+++ b/a2a_example.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-Agent A2A d’exemple : renvoie les messages utilisateur en MAJUSCULES.
+Agent A2A d’exemple « Echo+ ».
 
-Correction :
-  • compatibilité SDK a2a >= 0.5 : context.params ⇒ context._params
-    (fallback automatique si .params revient plus tard).
-  • oubli de « await » sur event_queue.enqueue_event() corrigé.
+Ce petit serveur illustre un agent « ping‑pong » personnalisable :
+
+* Choix de la transformation (« style ») : MAJUSCULES, minuscules,
+  *snake_case*, etc.
+* Mémoire très simple par `context_id` pour répondre à un ping‑pong de base.
+
+Cette nouvelle version remplace l’ancien agent « Uppercase » en le
+généralisant.
 """
 
 import asyncio
@@ -27,53 +31,62 @@ from a2a.server.apps import A2AStarletteApplication
 
 
 # --------------------------------------------------------------------------- #
-# Logique métier : transformer un texte en majuscules                         #
+# Logique métier : transformer un texte selon un "style"                      #
 # --------------------------------------------------------------------------- #
-class UppercaseAgent:
-    """Agent minimal : transforme le texte en majuscules."""
+class EchoAgent:
+    """Agent minimal permettant plusieurs styles de transformation."""
 
-    async def transform(self, text: str) -> str:
-        # petite latence simulée
-        await asyncio.sleep(0.1)
-        return text.upper()
+    async def transform(self, text: str, style: str) -> str:
+        """Applique la transformation demandée."""
+        await asyncio.sleep(0.1)  # petite latence simulée
+
+        if style == "uppercase":
+            return text.upper()
+        if style == "lowercase":
+            return text.lower()
+        if style == "snake_case":
+            return text.replace(" ", "_").lower()
+
+        # Style inconnu : renvoyer tel quel
+        return text
 
 
 # --------------------------------------------------------------------------- #
 # Exécuteur qui relie l’agent aux requêtes A2A                                #
 # --------------------------------------------------------------------------- #
-class UppercaseAgentExecutor(AgentExecutor):
-    """Implémentation de AgentExecutor pour l’écho en MAJUSCULES."""
+class EchoAgentExecutor(AgentExecutor):
+    """Relie l’agent Echo+ aux requêtes A2A."""
 
     def __init__(self) -> None:
-        self.agent = UppercaseAgent()
-
+        self.agent = EchoAgent()
+        self.memory: dict[str, list[Message]] = {}
+        
     async def execute(
         self,
         context: RequestContext,
         event_queue: EventQueue,
     ) -> None:
-        """
-        Gère les appels message/send et message/stream.
+        """Gère les appels ``message/send`` et ``message/stream``."""
 
-        Étapes :
-          1. Récupérer le Message utilisateur (params.message)
-          2. Extraire le texte
-          3. Le transformer
-          4. Enfiler la réponse dans la file d’événements
-        """
-        # 1. Récupérer les paramètres du message (SDK a2a >= 0.5 : ._params)
+        # 1. Paramètres et petite mémoire
         params: MessageSendParams = getattr(context, "params", context._params)
         user_message: Message = params.message
+        style = getattr(params, "style", "uppercase")
+        context_id = getattr(params, "context_id", None)
+
+        if context_id is not None:
+            history = self.memory.setdefault(context_id, [])
+            history.append(user_message)
 
         # 2. Concaténer les morceaux de texte
         user_text = " ".join(
             part.text for part in user_message.parts if getattr(part, "text", None)
         )
 
-        # 3. Transformer
-        transformed = await self.agent.transform(user_text)
+        # 3. Transformer selon le style demandé
+        transformed = await self.agent.transform(user_text, style)
 
-        # 4. Enfiler la réponse (IMPORTANT : await)
+        # 4. Enfiler la réponse (IMPORTANT : await)
         response_message = new_agent_text_message(transformed)
         await event_queue.enqueue_event(response_message)
 
@@ -86,18 +99,18 @@ class UppercaseAgentExecutor(AgentExecutor):
 # Définition du skill et de la carte agent                                    #
 # --------------------------------------------------------------------------- #
 skill = AgentSkill(
-    id="uppercase",
-    name="Uppercase Echo",
-    description="Retourne le texte en majuscules.",
-    tags=["echo", "uppercase"],
+    id="echo-plus",
+    name="Echo+",
+    description="Retourne le texte selon le style demandé.",
+    tags=["echo", "style"],
     examples=["bonjour", "hello"],
     input_modes=["text"],
     output_modes=["text"],
 )
 
 agent_card = AgentCard(
-    name="Uppercase Agent",
-    description="Un agent qui met vos messages en majuscules.",
+    name="Echo+ Agent",
+    description="Un agent qui applique différents styles aux messages.",
     url="http://localhost:9999/",
     version="1.0.0",
     default_input_modes=["text"],
@@ -111,7 +124,7 @@ agent_card = AgentCard(
 # Construction et démarrage de l’application Starlette                        #
 # --------------------------------------------------------------------------- #
 request_handler = DefaultRequestHandler(
-    agent_executor=UppercaseAgentExecutor(),
+    agent_executor=EchoAgentExecutor(),
     task_store=InMemoryTaskStore(),
 )
 

--- a/test_python.py
+++ b/test_python.py
@@ -12,7 +12,15 @@ async def main():
         client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
 
         # Non-streaming
-        payload = {"message": {"role": "user", "parts":[{"kind":"text","text":"salut"}], "messageId": uuid4().hex}}
+        payload = {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "salut"}],
+                "messageId": uuid4().hex,
+            },
+            "style": "snake_case",
+            "context_id": "demo",
+        }
         req = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**payload))
         res = await client.send_message(req)
         print("Réponse non‑streaming :", res.model_dump())


### PR DESCRIPTION
## Summary
- generalize simple uppercase agent into Echo+ agent with custom styles
- store small context history using `context_id`
- update docs and examples to demonstrate new features
- adapt client example to send style and context

## Testing
- `python -m py_compile a2a_example.py test_python.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_688917af632c8324926138cf06d06dab