### PR TITLE
Add LLM proxy agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Ce document décrit comment interagissent les deux scripts Python :
 | Script | Rôle | Point d’entrée |
 |--------|------|----------------|
 | **`a2a_example.py`** | Serveur : expose un agent A2A nommé *Echo+ Agent* capable d’appliquer plusieurs styles au texte (MAJUSCULES, minuscules, *snake_case*, …). | `uvicorn a2a_example:app …` |
+| **`a2a_llm_agent.py`** | Serveur : proxy vers l’API OpenAI avec résumé de documents. | `uvicorn a2a_llm_agent:app …` |
 | **`test_python.py`** | Client : découvre la carte A2A de l’agent, envoie un message une première fois en mode *non‑streaming*, puis refait la même requête en mode *streaming* SSE. | `python3 test_python.py` |
 
 ---
@@ -134,7 +135,10 @@ a2a-python>=0.5
 httpx>=0.26
 httpx-sse>=0.4
 uvicorn[standard]>=0.29
+openai>=1.0
 ```
+
+L’API OpenAI nécessite la variable d’environnement `OPENAI_API_KEY`.
 
 Verrouille la version du SDK pour éviter de futures ruptures :
 

--- a/a2a_llm_agent.py
+++ b/a2a_llm_agent.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""A2A agent exposing LLM and document analysis skills."""
+
+import os
+import asyncio
+from typing import Any
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    Message,
+    MessageSendParams,
+)
+from a2a.utils import new_agent_text_message
+from a2a.server.apps import A2AStarletteApplication
+
+from llm_agent import LLMProxy, DocumentAnalyzer, SkillRouter
+
+
+class RouterExecutor(AgentExecutor):
+    """Executor dispatching to the SkillRouter."""
+
+    def __init__(self) -> None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        llm = LLMProxy(api_key)
+        self.router = SkillRouter(llm, DocumentAnalyzer(llm))
+        self.memory: dict[str, list[Message]] = {}
+
+    async def execute(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        params: MessageSendParams = getattr(context, "params", context._params)
+        user_message: Message = params.message
+        context_id = getattr(params, "context_id", None)
+
+        if context_id is not None:
+            history = self.memory.setdefault(context_id, [])
+            history.append(user_message)
+
+        user_text = " ".join(
+            part.text for part in user_message.parts if getattr(part, "text", None)
+        )
+        try:
+            transformed = await self.router.execute(user_text)
+        except Exception as exc:
+            transformed = f"Erreur: {exc}"
+
+        response_message = new_agent_text_message(transformed)
+        await event_queue.enqueue_event(response_message)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        raise Exception("cancel not supported")
+
+
+llm_skill = AgentSkill(
+    id="llm-proxy",
+    name="LLM",
+    description="Proxy vers le modèle GPT/Claude via OpenAI API.",
+    tags=["llm"],
+    examples=["bonjour"],
+    input_modes=["text"],
+    output_modes=["text"],
+)
+
+summary_skill = AgentSkill(
+    id="doc-summary",
+    name="Analyse de documents",
+    description="Télécharge un PDF/URL et renvoie un résumé.",
+    tags=["summary"],
+    examples=["https://example.com/doc.pdf"],
+    input_modes=["text"],
+    output_modes=["text"],
+)
+
+agent_card = AgentCard(
+    name="LLM Agent",
+    description="Proxy LLM avec résumé de documents.",
+    url="http://localhost:9999/",
+    version="1.0.0",
+    default_input_modes=["text"],
+    default_output_modes=["text"],
+    capabilities=AgentCapabilities(streaming=True),
+    skills=[llm_skill, summary_skill],
+    supports_authenticated_extended_card=False,
+)
+
+request_handler = DefaultRequestHandler(
+    agent_executor=RouterExecutor(),
+    task_store=InMemoryTaskStore(),
+)
+
+app = A2AStarletteApplication(
+    agent_card=agent_card,
+    http_handler=request_handler,
+).build()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("a2a_llm_agent:app", host="0.0.0.0", port=9999, reload=True)

--- a/llm_agent.py
+++ b/llm_agent.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""LLM and document summarization agent."""
+
+import os
+import asyncio
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+import httpx
+
+
+class LLMProxy:
+    """Very small wrapper around the OpenAI chat API."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+
+    async def run(self, prompt: str) -> str:
+        if openai is None:
+            raise RuntimeError("openai package is not installed")
+        client = openai.AsyncOpenAI(api_key=self.api_key)
+        resp = await client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content
+
+
+class DocumentAnalyzer:
+    """Fetches a document from a URL and returns a short summary using the LLMProxy."""
+
+    def __init__(self, llm: LLMProxy) -> None:
+        self.llm = llm
+
+    async def analyze(self, url: str) -> str:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(url, timeout=10.0)
+            r.raise_for_status()
+            text = r.text[:2000]
+        prompt = f"Résume en français ce contenu:\n{text}"
+        return await self.llm.run(prompt)
+
+
+class SkillRouter:
+    """Naive router that chooses the right skill based on parameters."""
+
+    def __init__(self, llm: LLMProxy, analyzer: DocumentAnalyzer) -> None:
+        self.llm = llm
+        self.analyzer = analyzer
+
+    async def execute(self, message: str) -> str:
+        if message.startswith("http://") or message.startswith("https://"):
+            return await self.analyzer.analyze(message)
+        return await self.llm.run(message)
+
+
+async def demo() -> None:
+    api_key = os.getenv("OPENAI_API_KEY")
+    router = SkillRouter(LLMProxy(api_key), DocumentAnalyzer(LLMProxy(api_key)))
+    res = await router.execute("Bonjour")
+    print(res)
+
+
+if __name__ == "__main__":
+    asyncio.run(demo())


### PR DESCRIPTION
## Summary
- create `llm_agent` utilities with OpenAI proxy and document summarizer
- add `a2a_llm_agent` exposing the LLM and summarization skills
- document new script and dependencies in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6889c0386f7083249bbcce011036f4dd